### PR TITLE
슬라이딩 사이드바 및 해당 부분 반응형 구현 완료

### DIFF
--- a/src/components/Button.components.js
+++ b/src/components/Button.components.js
@@ -1,0 +1,73 @@
+import { forwardRef } from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+import { colors, device } from "../styles/Theme";
+
+export const Button = forwardRef(
+  ({ icon, disabled, to, children, navOpen }, ref) => {
+    const IconComponent = icon;
+
+    return (
+      <LinkContainer to={to} ref={ref} disabled={disabled}>
+        <IconComponent />
+        {children}
+      </LinkContainer>
+    );
+  }
+);
+
+const hoverEffect = {
+  enabled: {
+    "background-color": colors.hoverWhite,
+    border: `3px dotted ${colors.hoverWhite}`,
+  },
+  disabled: {
+    border: `2px dotted ${colors.hoverWhite}`,
+    cursor: "not-allowed",
+    opacity: "0.5",
+  },
+};
+
+const LinkContainer = styled(Link)`
+  position: relative;
+  padding: 10px 50px;
+  width: 100%;
+  height: 70px;
+  display: inline-block;
+  text-align: end;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  > svg {
+    position: absolute;
+    left: 50px;
+    width: 40px;
+    height: 40px;
+    margin-right: 20px;
+    color: ${colors.white};
+  }
+
+  ${device.desktop} {
+    padding: 20px;
+    text-align: end;
+    justify-content: space-between;
+    align-items: center;
+
+    > svg {
+      position: static;
+      width: 40px;
+      height: 40px;
+      margin-right: 20px;
+      color: ${colors.white};
+    }
+  }
+
+  &:hover {
+    ${({ disabled }) =>
+      disabled ? { ...hoverEffect.disabled } : { ...hoverEffect.enabled }};
+  }
+
+  &:disabled {
+  }
+`;

--- a/src/components/Button.components.js
+++ b/src/components/Button.components.js
@@ -34,7 +34,6 @@ const LinkContainer = styled(Link)`
   width: 100%;
   height: 70px;
   display: inline-block;
-  text-align: end;
   display: flex;
   justify-content: center;
   align-items: center;
@@ -44,12 +43,12 @@ const LinkContainer = styled(Link)`
     left: 50px;
     width: 40px;
     height: 40px;
-    color: ${colors.white};
   }
 
   ${device.desktop} {
     padding: 20px;
-    justify-content: space-between;
+    justify-content: flex-start;
+    gap: 20px;
 
     > svg {
       position: static;
@@ -63,8 +62,5 @@ const LinkContainer = styled(Link)`
   &:hover {
     ${({ disabled }) =>
       disabled ? { ...hoverEffect.disabled } : { ...hoverEffect.enabled }};
-  }
-
-  &:disabled {
   }
 `;

--- a/src/components/Button.components.js
+++ b/src/components/Button.components.js
@@ -4,13 +4,13 @@ import styled from "styled-components";
 import { colors, device } from "../styles/Theme";
 
 export const Button = forwardRef(
-  ({ icon, disabled, to, children, navOpen }, ref) => {
+  ({ icon, disabled, to, children, navopen }, ref) => {
     const IconComponent = icon;
 
     return (
-      <LinkContainer to={to} ref={ref} disabled={disabled}>
+      <LinkContainer to={to} ref={ref} disabled={disabled} navopen={navopen}>
         <IconComponent />
-        {children}
+        <div>{children}</div>
       </LinkContainer>
     );
   }
@@ -44,22 +44,19 @@ const LinkContainer = styled(Link)`
     left: 50px;
     width: 40px;
     height: 40px;
-    margin-right: 20px;
     color: ${colors.white};
   }
 
   ${device.desktop} {
     padding: 20px;
-    text-align: end;
     justify-content: space-between;
-    align-items: center;
 
     > svg {
       position: static;
-      width: 40px;
-      height: 40px;
-      margin-right: 20px;
-      color: ${colors.white};
+    }
+
+    > div {
+      display: none;
     }
   }
 

--- a/src/components/Sidebar.components.js
+++ b/src/components/Sidebar.components.js
@@ -1,16 +1,18 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
 import styled from "styled-components";
 import { GiHamburgerMenu } from "react-icons/gi";
-import { IoCloseSharp } from "react-icons/io5";
+import { FaUser, FaRegClipboard, FaPowerOff } from "react-icons/fa";
+import { IoSettingsSharp, IoCloseSharp } from "react-icons/io5";
 
 import { colors, device } from "../styles/Theme";
+
+import { Button } from "./_index.components";
 
 export const Sidebar = () => {
   const [navOpen, setNavOpen] = useState(false);
 
   function toggleMenu(navOpen) {
-    setNavOpen((navOpen) => {
+    setNavOpen(navOpen => {
       return !navOpen;
     });
   }
@@ -22,16 +24,24 @@ export const Sidebar = () => {
       </MenuButton>
       <NavList>
         <NavItem navOpen={navOpen} onClick={() => setNavOpen(false)}>
-          <Link to="/">사용자1</Link>
+          <Button mode="button" to="/" icon={FaUser}>
+            사용자1
+          </Button>
         </NavItem>
         <NavItem navOpen={navOpen} onClick={() => setNavOpen(false)}>
-          <Link to="/board">게시판</Link>
+          <Button to="/board" icon={FaRegClipboard}>
+            게시판
+          </Button>
         </NavItem>
         <NavItem navOpen={navOpen} onClick={() => setNavOpen(false)}>
-          <Link to="#">개인설정</Link>
+          <Button disabled to="#" icon={IoSettingsSharp}>
+            개인설정
+          </Button>
         </NavItem>
         <NavItem navOpen={navOpen} onClick={() => setNavOpen(false)}>
-          <Link to="#">로그아웃</Link>
+          <Button disabled to="#" icon={FaPowerOff}>
+            로그아웃
+          </Button>
         </NavItem>
       </NavList>
     </SidebarContainer>
@@ -97,19 +107,6 @@ const NavItem = styled.li`
   display: ${({ navOpen }) => (navOpen ? "block" : "none")};
   width: 100%;
   color: ${colors.white};
-
-  > a {
-    padding: 10px 20px;
-    width: 100%;
-    height: 70px;
-    display: inline-block;
-    text-align: end;
-    line-height: 50px;
-
-    &:hover {
-      background-color: ${colors.hoverWhite};
-    }
-  }
 
   ${device.desktop} {
     display: block;

--- a/src/components/Sidebar.components.js
+++ b/src/components/Sidebar.components.js
@@ -54,7 +54,6 @@ const SidebarContainer = styled.nav`
   flex-direction: column;
   align-items: flex-end;
   background-color: ${colors.darkgray};
-  /* color: ${colors.white}; */
 
   ${device.desktop} {
     width: 70px;
@@ -80,7 +79,6 @@ const MenuButton = styled.button`
   svg {
     width: 70px;
     height: 70px;
-    color: ${colors.white};
   }
 
   ${device.desktop} {
@@ -89,9 +87,9 @@ const MenuButton = styled.button`
 `;
 
 const NavList = styled.ul`
-  display: ${({ navOpen }) => (navOpen ? "block" : "none")};
   width: 100%;
   height: ${({ navOpen }) => (navOpen ? "100vh" : "0px")};
+  display: ${({ navOpen }) => (navOpen ? "block" : "none")};
   display: flex;
   flex-direction: column;
   align-items: flex-end;
@@ -107,8 +105,8 @@ const NavList = styled.ul`
 `;
 
 const NavItem = styled.li`
-  display: ${({ navOpen }) => (navOpen ? "block" : "none")};
   width: 100%;
+  display: ${({ navOpen }) => (navOpen ? "block" : "none")};
   color: ${colors.white};
 
   ${device.desktop} {

--- a/src/components/Sidebar.components.js
+++ b/src/components/Sidebar.components.js
@@ -54,18 +54,21 @@ const SidebarContainer = styled.nav`
   flex-direction: column;
   align-items: flex-end;
   background-color: ${colors.darkgray};
+  /* color: ${colors.white}; */
 
   ${device.desktop} {
-    width: 100px;
+    width: 70px;
     min-width: fit-content;
     height: 100vh;
     gap: 80px;
-    background-color: ${colors.darkgray};
-    color: ${colors.white};
-    transition: width 0.8s ease;
 
     &:hover {
-      width: 300px;
+      transition: all 0.2s ease;
+      width: 200px;
+
+      div {
+        display: block;
+      }
     }
   }
 `;

--- a/src/components/_index.components.js
+++ b/src/components/_index.components.js
@@ -1,1 +1,2 @@
+export * from "./Button.components";
 export * from "./Sidebar.components";


### PR DESCRIPTION
# 체크리스트
- [x] 리팩토링 및 코드 정리 완료
- [x] 재사용 되는 메뉴 버튼을 컴포넌트로 분리 

데스크탑 스크린에서:
- [x] 호버 전 아이콘만 보이는 사이드바
- [x] 호버 시 아이콘과 해당 메뉴의 텍스트도 보이게 적용
- [x] 링크가 없는 메뉴는 호버시 다른 스타일 적용
- [x] 메뉴텍스트 오른쪽 정렬에서 왼쪽 정렬로 수정

# 구현 화면:

https://user-images.githubusercontent.com/75428629/196539913-cce6fa48-6185-43ef-9428-2f4f1cb30381.mov

